### PR TITLE
Control `TimeInputId` format

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,10 +7,10 @@ jobs:
     name: codecov
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.17
+      - name: Set up Go 1.19
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.17
+      - name: Set up Go 1.19
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,20 +15,20 @@ jobs:
     name: build-test
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.17
+      - name: Set up Go 1.19
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
-          
+          go-version: 1.19
+
       - uses: actions/checkout@v2
-        
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           push: false
 
       - name: Run Go Build
-        run: | 
+        run: |
           go build .
 
   golangci:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 prepare:
 	GOBIN=$(BIN_DIR) go install github.com/mitchellh/gox
 
-build:
+build: prepare
 	$(BIN_DIR)/gox \
 	-osarch="darwin/amd64 linux/amd64 windows/amd64" \
 	-output "build/{{.OS}}-{{.Arch}}/$(NAME)" \

--- a/commands/request.go
+++ b/commands/request.go
@@ -3,19 +3,16 @@ package commands
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
-	"github.com/perkbox/cloud-access-bot/internal/messenger"
-
-	uuid "github.com/satori/go.uuid"
-
 	"github.com/perkbox/cloud-access-bot/internal"
-
+	"github.com/perkbox/cloud-access-bot/internal/messenger"
+	"github.com/perkbox/cloud-access-bot/internal/settings"
 	"github.com/perkbox/cloud-access-bot/internal/utils"
 
-	"github.com/perkbox/cloud-access-bot/internal/settings"
-
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 
 	"github.com/slack-go/slack"
@@ -211,6 +208,14 @@ func (c *SlashCommandController) requestModelSubmitted(evt *socketmode.Event, cl
 	selActions := c.Service.IdentityData.FindActionsById(actionIds)
 
 	selResources := messenger.GetValuesFromSelectedOptions(viewCallabck.View.State.Values[fmt.Sprintf("%s:%s", messenger.IamResourcesSelectorActionID, selService)][messenger.IamResourcesSelectorActionID].SelectedOptions)
+
+	if _, err := strconv.Atoi(requestDuration); err != nil {
+		resp := slack.NewErrorsViewSubmissionResponse(map[string]string{
+			fmt.Sprintf("%s", messenger.TimeInputID): "Enter the duration indicating the number of minutes",
+		})
+		clt.Ack(*evt.Request, resp)
+		return
+	}
 
 	if len(selResources) != 0 {
 		policyResources = c.Service.FindSelectedCloudResoucesNames(selService, viewCallabck.View.PrivateMetadata, selResources)

--- a/commands/request.go
+++ b/commands/request.go
@@ -211,7 +211,7 @@ func (c *SlashCommandController) requestModelSubmitted(evt *socketmode.Event, cl
 
 	if _, err := strconv.Atoi(requestDuration); err != nil {
 		resp := slack.NewErrorsViewSubmissionResponse(map[string]string{
-			fmt.Sprintf("%s", messenger.TimeInputID): "Enter the duration indicating the number of minutes",
+			messenger.TimeInputID: "Enter the duration indicating the number of minutes",
 		})
 		clt.Ack(*evt.Request, resp)
 		return

--- a/commands/request.go
+++ b/commands/request.go
@@ -120,7 +120,7 @@ func (c *SlashCommandController) updateViewAccountSelect(evt *socketmode.Event, 
 		return
 	}
 
-	client := clt.GetApiClient()
+	client := clt.Client
 	clt.Ack(*evt.Request)
 
 	viewBody, err := c.Service.Messenger.GenerateModal("accountSelectView", c.Settings.GetAccountNames(), c.Settings.GetLoginRoles(), false, "", "")
@@ -142,7 +142,7 @@ func (c *SlashCommandController) updateViewServices(evt *socketmode.Event, clt *
 		logrus.Errorf("ERROR converting event to Update View")
 		return
 	}
-	client := clt.GetApiClient()
+	client := clt.Client
 
 	selService := actionCallback.View.State.Values[messenger.IamServicesSelectorActionID][messenger.IamServicesSelectorActionID].SelectedOption.Value
 	selAccount := actionCallback.View.State.Values[messenger.AccountSelectorActionId][messenger.AccountSelectorActionId].SelectedOption.Value
@@ -171,7 +171,7 @@ func (c *SlashCommandController) handleRequestStart(evt *socketmode.Event, clt *
 	}
 
 	clt.Ack(*evt.Request)
-	client := clt.GetApiClient()
+	client := clt.Client
 
 	viewBody, err := c.Service.Messenger.GenerateModal("firstView", c.Settings.GetAccountNames(), c.Settings.GetLoginRoles(), false, "", "")
 	if err != nil {
@@ -229,7 +229,7 @@ func (c *SlashCommandController) requestModelSubmitted(evt *socketmode.Event, cl
 
 	clt.Ack(*evt.Request)
 
-	client := clt.GetApiClient()
+	client := clt.Client
 	id, err := client.GetUserInfo(viewCallabck.User.ID)
 	if err != nil {
 		logrus.Errorf("Error getting User info for %s Err: %s", viewCallabck.User.ID, err.Error())

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/perkbox/cloud-access-bot
 
-go 1.17
-
-replace github.com/slack-go/slack => github.com/xnok/slack v0.8.1-0.20210509200330-9b2b404dbde9
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.40.46
@@ -23,7 +21,7 @@ require (
 	github.com/joho/godotenv v1.4.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.8.1
-	github.com/slack-go/slack v0.0.0-00010101000000-000000000000
+	github.com/slack-go/slack v0.11.3
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
@@ -40,7 +38,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.5.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,6 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
 github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -81,12 +79,12 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/slack-go/slack v0.11.3 h1:GN7revxEMax4amCc3El9a+9SGnjmBvSUobs0QnO6ZO8=
+github.com/slack-go/slack v0.11.3/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/xnok/slack v0.8.1-0.20210509200330-9b2b404dbde9 h1:BzZdNA8e9IhWqcQrWfns5H/EzxWr+igkLNM8gLsSkzI=
-github.com/xnok/slack v0.8.1-0.20210509200330-9b2b404dbde9/go.mod h1:wWL//kk0ho+FcQXcBTmEafUI5dz4qz5f4mMk8oIkioQ=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/messenger/assets/acessmodal.json
+++ b/internal/messenger/assets/acessmodal.json
@@ -37,7 +37,7 @@
       },
       "hint": {
         "type": "plain_text",
-        "text": "Enter the time as number minutes, e.g. 60"
+        "text": "Enter the time as number of minutes, e.g. 60"
       }
     },
     {

--- a/internal/messenger/assets/acessmodal.json
+++ b/internal/messenger/assets/acessmodal.json
@@ -34,6 +34,10 @@
         "type": "plain_text",
         "text": "Enter Time for Extended Permissions",
         "emoji": true
+      },
+      "hint": {
+        "type": "plain_text",
+        "text": "Enter the time as number minutes, e.g. 60"
       }
     },
     {


### PR DESCRIPTION
- Bump go to `1.19`
- Bump `slack-go` to `v0.11.3`, so no need to link with external fork to use socket mode handler as it is now part of the `slack-go`
- Add validation for `TimeInputID` field and display error in view
- Update iam definitions from https://github.com/salesforce/policy_sentry